### PR TITLE
Add docker files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+target/
+.idea/
+*.iml
+.vscode/
+*.log
+.env 
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM eclipse-temurin:24-jdk as build
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY src src
+
+RUN chmod +x ./mvnw
+RUN ./mvnw install -DskipTests
+RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*.jar)
+
+FROM eclipse-temurin:24-jre
+VOLUME /tmp
+ARG DEPENDENCY=/workspace/app/target/dependency
+COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
+COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
+COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
+ENTRYPOINT ["java","-cp","app:app/lib/*","com.ross.ese.taskmanager.TaskmanagerApplication"]


### PR DESCRIPTION
This pull request introduces Docker support for the project, including the addition of a `.dockerignore` file and a `Dockerfile` to build and run the application in a Docker container.

Docker support:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R10): Added to exclude unnecessary files and directories from the Docker build context, such as `.git`, `.idea/`, `*.log`, and others.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R19): Added to define the multi-stage build process for the application, using `eclipse-temurin` images for both building and running the application. This includes copying necessary files, running Maven to install dependencies, and setting up the application to run with the appropriate classpath.