### PR TITLE
Fix wrong jdk version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:24-jdk as build
+FROM eclipse-temurin:17-jdk as build
 WORKDIR /workspace/app
 
 COPY mvnw .
@@ -10,7 +10,7 @@ RUN chmod +x ./mvnw
 RUN ./mvnw install -DskipTests
 RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*.jar)
 
-FROM eclipse-temurin:24-jre
+FROM eclipse-temurin:17-jre
 VOLUME /tmp
 ARG DEPENDENCY=/workspace/app/target/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to update the base image versions for both the build and runtime environments.

* Updated the base image for the build stage from `eclipse-temurin:24-jdk` to `eclipse-temurin:17-jdk`.
* Updated the base image for the runtime stage from `eclipse-temurin:24-jre` to `eclipse-temurin:17-jre`.