### PR TITLE
Fix database connection bug

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,3 +1,7 @@
 app.auth.dev-mode=true
 logging.level.org.springframework.security=DEBUG
 logging.level.com.ross.ese.taskmanager=DEBUG
+
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,12 +5,6 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
-# JPA/Hibernate
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-
 # Server Configuration
 server.port=8080
 
@@ -44,3 +38,35 @@ spring.mvc.async.request-timeout=30000
 server.tomcat.max-threads=200
 server.tomcat.max-connections=8192
 server.tomcat.accept-count=100
+
+# Connection pool configuration
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=600000
+spring.datasource.hikari.max-lifetime=1800000
+
+# PostgreSQL settings
+spring.datasource.hikari.data-source-properties.reWriteBatchedInserts=true
+spring.datasource.hikari.data-source-properties.cachePrepStmts=true
+spring.datasource.hikari.data-source-properties.prepStmtCacheSize=250
+spring.datasource.hikari.data-source-properties.prepStmtCacheSqlLimit=2048
+spring.datasource.hikari.auto-commit=false
+spring.datasource.hikari.data-source-properties.useServerPrepStmts=false
+
+# JPA/Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.jdbc.use_get_generated_keys=true
+spring.jpa.properties.hibernate.jdbc.batch_size=30
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.enable_lazy_load_no_trans=false
+spring.jpa.properties.hibernate.jdbc.fetch_size=100
+spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+spring.jpa.properties.hibernate.jdbc.use_streams_for_binary=true
+spring.jpa.properties.hibernate.query.plan_cache_max_size=2048 
+spring.jpa.properties.hibernate.query.plan_parameter_metadata_max_size=128
+spring.jpa.properties.hibernate.jdbc.batch_versioning=true  


### PR DESCRIPTION
This pull request includes several changes to the configuration properties for the Spring application. The changes focus on adding database connection settings, configuring the connection pool, and updating JPA/Hibernate settings.

Database connection settings:

* [`src/main/resources/application-dev.properties`](diffhunk://#diff-cbee934a0dc2d724591feb74d9e4200e997b60b1f2b2a41b51336a0c83ab42b9R4-R7): Added properties for `spring.datasource.url`, `spring.datasource.username`, and `spring.datasource.password`.

Connection pool configuration:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R41-R72): Added Hikari connection pool configuration properties including `spring.datasource.hikari.maximum-pool-size`, `spring.datasource.hikari.minimum-idle`, `spring.datasource.hikari.connection-timeout`, `spring.datasource.hikari.idle-timeout`, and `spring.datasource.hikari.max-lifetime`.

JPA/Hibernate settings:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R41-R72): Added JPA/Hibernate properties such as `spring.jpa.hibernate.ddl-auto`, `spring.jpa.show-sql`, `spring.jpa.properties.hibernate.format_sql`, and `spring.jpa.properties.hibernate.dialect`.
* Removed old JPA/Hibernate settings from `src/main/resources/application.properties` to avoid duplication and ensure consistency.